### PR TITLE
Make convertkit-ruby compatible with Ruby 2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'dotenv', '~> 2.1', '>= 2.1.1'
-gem 'webmock', '~> 2.1'
+gem 'webmock', '~> 3.5'
 gem 'vcr', '~> 3.0', '>= 3.0.3'


### PR DESCRIPTION
Bump Webmock to 3.5 - this is the oldest version of WebMock that supports Ruby 2.6.